### PR TITLE
Rubocop Style Fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+; Use 2 spaces for indentation in all files
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+insert_final_newline = true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+Metrics/AbcSize:
+  Max: 18
+
+Metrics/LineLength:
+  Max: 120
+
+Style/Documentation:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec) { |t| task default: :spec }
+RSpec::Core::RakeTask.new(:spec) { |_t| task default: :spec }
 
 task default: :spec

--- a/cricketer.gemspec
+++ b/cricketer.gemspec
@@ -1,25 +1,26 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name          = "cricketer"
-  spec.version       = "0.0.2"
-  spec.authors       = ["Derek Willis"]
-  spec.email         = ["dwillis@gmail.com"]
-  spec.summary       = %q{A Ruby library for parsing data from ESPN's Cricinfo site.}
-  spec.description   = %q{Parses live scores and game data.}
-  spec.homepage      = "https://github.com/dwillis/cricketer"
-  spec.license       = "MIT"
+  spec.name          = 'cricketer'
+  spec.version       = '0.0.2'
+  spec.authors       = ['Derek Willis']
+  spec.email         = ['dwillis@gmail.com']
+  spec.summary       = "A Ruby library for parsing data from ESPN's Cricinfo site."
+  spec.description   = 'Parses live scores and game data.'
+  spec.homepage      = 'https://github.com/dwillis/cricketer'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "fast_attributes", "~> 0.7"
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.2.0"
-  spec.add_development_dependency "vcr", "~> 2.9.3"
+  spec.add_dependency 'fast_attributes', '~> 0.7'
+  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.2.0'
+  spec.add_development_dependency 'vcr', '~> 2.9.3'
+  spec.add_development_dependency 'webmock', '~> 3.3'
 end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -2,19 +2,18 @@ module Cricketer
   class API
     extend FastAttributes
 
-    URL_BASE = "http://www.espncricinfo.com/matches/engine/match"
+    URL_BASE = 'http://www.espncricinfo.com/matches/engine/match'.freeze
 
     define_attributes initialize: true, attributes: true do
       attribute :match_id, Integer
     end
 
     def url
-      [URL_BASE, "#{ match_id }.json"].join("/")
+      [URL_BASE, "#{match_id}.json"].join('/')
     end
 
     def content
       @content ||= JSON.parse(open(url).read)
     end
-
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Cricketer
-  VERSION = "0.0.2"
+  VERSION = '0.0.2'.freeze
 end

--- a/lib/world_cup.rb
+++ b/lib/world_cup.rb
@@ -1,12 +1,25 @@
 module Cricketer
   class WorldCup
-
     def self.points_table
-      url = "http://www.espncricinfo.com/wc2007/engine/series/509587.json?view=pointstable"
+      url = 'http://www.espncricinfo.com/wc2007/engine/series/509587.json?view=pointstable'
       points = JSON.parse(open(url).read)
-      pool_a = points['graph']["Pool A"].keys.map{|k| {id: k, name: points['graph']["Pool A"][k]['team_name'], matches: points['graph']["Pool A"][k]['points'].size, points: points['graph']["Pool A"][k]['points'].last['points']}}
-      pool_b = points['graph']["Pool B"].keys.map{|k| {id: k, name: points['graph']["Pool B"][k]['team_name'], matches: points['graph']["Pool B"][k]['points'].size, points: points['graph']["Pool B"][k]['points'].last['points']}}
-      [pool_a.sort_by!{|h| h[:points]}.reverse, pool_b.sort_by!{|h| h[:points]}.reverse]
+      pool_a = get_graph_pool(points, 'Pool A')
+      pool_b = get_graph_pool(points, 'Pool B')
+      [pool_a.sort_by! { |h| h[:points] }.reverse, pool_b.sort_by! { |h| h[:points] }.reverse]
+    end
+
+    private_class_method
+
+    def self.get_graph_pool(points, name)
+      pool = points['graph'][name]
+      pool.keys.map do |k|
+        {
+          id: k,
+          name: pool[k]['team_name'],
+          matches: pool[k]['points'].size,
+          points: pool[k]['points'].last['points']
+        }
+      end
     end
   end
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Cricketer::API do
   subject { Cricketer::API }
-  let(:match_id) { 656399 }
+  let(:match_id) { 656_399 }
 
   let(:api) do
     VCR.use_cassette("match_#{match_id}") do
@@ -11,9 +11,9 @@ RSpec.describe Cricketer::API do
   end
 
   context 'produces valid url' do
-
     it 'matches the url' do
-      expect(api.url).to eq "http://www.espncricinfo.com/matches/engine/match/#{match_id}.json"
+      url = "http://www.espncricinfo.com/matches/engine/match/#{match_id}.json"
+      expect(api.url).to eq url
     end
   end
 end

--- a/spec/match_spec.rb
+++ b/spec/match_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Cricketer::Match do
   subject { Cricketer::Match }
-  let(:match_id) { 656399 }
+  let(:match_id) { 656_399 }
 
   let(:match) do
     VCR.use_cassette("match_#{match_id}") do
@@ -11,9 +11,9 @@ RSpec.describe Cricketer::Match do
   end
 
   context 'produces valid data' do
-
     it 'describes the match with #to_s' do
-      expect(match.to_s).to eq 'ICC Cricket World Cup, 1st Match, Pool A: New Zealand v Sri Lanka at Christchurch, Feb 14, 2015'
+      expect(match.to_s).to eq 'ICC Cricket World Cup, 1st Match, Pool A: '\
+                                'New Zealand v Sri Lanka at Christchurch, Feb 14, 2015'
     end
 
     it 'returns the current status' do
@@ -21,8 +21,7 @@ RSpec.describe Cricketer::Match do
     end
 
     it 'returns team data' do
-       expect(match.team1.name).to eq 'New Zealand'
+      expect(match.team1.name).to eq 'New Zealand'
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'vcr'
 
 # Ensure that the load path has the lib folder accessible
 # in the test environment
-lib = File.expand_path('../../lib', __FILE__)
+lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 # Require the entry point for the gem
@@ -32,9 +32,7 @@ RSpec.configure do |config|
   #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
   config.disable_monkey_patching!
 
-  if config.files_to_run.one?
-    config.default_formatter = 'doc'
-  end
+  config.default_formatter = 'doc' if config.files_to_run.one?
 
   config.order = :random
 end

--- a/spec/world_cup_spec.rb
+++ b/spec/world_cup_spec.rb
@@ -4,16 +4,14 @@ RSpec.describe Cricketer::WorldCup do
   subject { Cricketer::WorldCup }
 
   let(:points_table) do
-    VCR.use_cassette("points_table") do
+    VCR.use_cassette('points_table') do
       subject.points_table
     end
   end
 
   context 'produces valid data' do
-
     it 'describes the first team in the first pool by name' do
       expect(points_table[0][0][:name]).to eq 'New Zealand'
     end
   end
-
 end


### PR DESCRIPTION
Running Rubocop on this gem gave this output: [Log link](https://gist.githubusercontent.com/harman28/f2fb48aad197212b790a9e8721f9a941/raw/c90d50e5d23f310278958d3456283c77cfeb1e06/rubocop_cricketer_280318.log)

```
13 files inspected, 120 offenses detected
```

Fixed or ignored most of these below. Also added an editorconfig file.

New output of rubocop:
```
Offenses:

lib/api.rb:16:31: C: Security/Open: The use of Kernel#open is a serious security risk.
      @content ||= JSON.parse(open(url).read)
                              ^^^^
lib/world_cup.rb:5:27: C: Security/Open: The use of Kernel#open is a serious security risk.
      points = JSON.parse(open(url).read)
                          ^^^^

13 files inspected, 2 offenses detected
```
Reading up on a suitable alternative.